### PR TITLE
Debug object prototype error in bundle

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { ToastContainer } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css'
+import { Provider } from 'react-redux';
+import { store } from './src/app/store';
 import Screen from './src/screens/Screen';
 import RegisterScreen from './src/screens/RegisterScreen';
 import LoginScreen from './src/screens/LoginScreen';
@@ -11,7 +11,7 @@ const Stack = createNativeStackNavigator();
 
 export default function App() {
   return (
-    <>
+    <Provider store={store}>
       <NavigationContainer>
         <Stack.Navigator 
           initialRouteName="Login"
@@ -51,9 +51,6 @@ export default function App() {
           />
         </Stack.Navigator>
       </NavigationContainer>
-      <ToastContainer/>
-    </>
-
-
+    </Provider>
   );
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,8 +22,7 @@
         "react-native": "0.79.5",
         "react-native-dotenv": "^3.4.11",
         "react-native-web": "^0.20.0",
-        "react-redux": "^9.2.0",
-        "react-toastify": "^11.0.5"
+        "react-redux": "^9.2.0"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0"
@@ -3401,15 +3400,6 @@
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/color": {
@@ -6835,19 +6825,6 @@
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-toastify": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
-      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.1.1"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/read": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,8 +24,7 @@
     "react-native": "0.79.5",
     "react-native-dotenv": "^3.4.11",
     "react-native-web": "^0.20.0",
-    "react-redux": "^9.2.0",
-    "react-toastify": "^11.0.5"
+    "react-redux": "^9.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/frontend/src/features/auth/authSlice.js
+++ b/frontend/src/features/auth/authSlice.js
@@ -10,11 +10,9 @@ const initialState = {
     message: '',
 }
 
-export const register = createAsyncThunk('auth/register', async (user, thunkAPI) => {
+export const register = createAsyncThunk('auth/register', async (userData, thunkAPI) => {
     try {
-        const user = await AsyncStorage.getItem('user')
-
-        return await authService.register(user)
+        return await authService.register(userData)
     } catch (error) {
         const message = 
             (error.response && error.response.data && error.response.data.message) 


### PR DESCRIPTION
Resolve 'Object prototype may only be an Object or null: undefined' error by correctly configuring Redux and removing incompatible libraries.

The primary cause of the error was the absence of the Redux `Provider` wrapping the application, leading to `useSelector` and `useDispatch` hooks failing to find the Redux context. Additionally, `react-toastify` was removed as it's not compatible with React Native, and a variable name conflict in the `authSlice` register thunk was resolved.

---

[Open in Web](https://www.cursor.com/agents?id=bc-54e3dc0e-6b69-4153-af80-792ad9ef3e18) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-54e3dc0e-6b69-4153-af80-792ad9ef3e18)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)