### PR TITLE
Debug object prototype error during module load

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -12,8 +12,7 @@ const Stack = createNativeStackNavigator();
 
 export default function App() {
   return (
-    <Provider>
-
+    <Provider store={store}>
       <NavigationContainer>
         <Stack.Navigator 
           initialRouteName="Login"


### PR DESCRIPTION
Add `store` prop to Redux `Provider` to resolve `TypeError: Object prototype may only be an Object or null: undefined`.

The `TypeError` occurred because the Redux `Provider` component was initialized without the `store` prop, leading to an undefined store context when Redux components attempted to create objects.

---

[Open in Web](https://www.cursor.com/agents?id=bc-ed1511a9-6bb9-4c08-9d34-ece4c4d930f8) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ed1511a9-6bb9-4c08-9d34-ece4c4d930f8)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)